### PR TITLE
Handling when raw_data is None

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: python
+
 python:
   - "3.5"
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
+
+# updating pip 
+before_install:
+  - pip install --upgrade pip tox virtualenv
+
 # command to install dependencies
 install:
-  - pip install -U pip
   - pip install -r tests/requirements.txt
-# command to run tests
 
+# command to run tests
 script:
   - flake8 --count --statistics django_ip_geolocation
   - bandit -r django_ip_geolocation

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"      # current default Python on Travis CI
   - "3.7"
   - "3.8"
+  - "3.9"
 
 # updating pip 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"      # current default Python on Travis CI
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.8"
 # command to install dependencies
 install:
+  - pip install -U pip
   - pip install -r tests/requirements.txt
 # command to run tests
 

--- a/django_ip_geolocation/backends/base.py
+++ b/django_ip_geolocation/backends/base.py
@@ -14,7 +14,7 @@ class GeolocationBackend(object):
         self._continent = None
         self._country = None
         self._geo_data = None
-        self._raw_data = None
+        self._raw_data = {}
 
     def geolocate(self):
         """Call geoloaction api. Should be overriden."""

--- a/django_ip_geolocation/backends/ipdataco.py
+++ b/django_ip_geolocation/backends/ipdataco.py
@@ -23,23 +23,12 @@ class IPDataCo(GeolocationBackend):
 
     def _parse(self):
         """Parse raw data."""
-        if self._raw_data:
-            self._continent = self._raw_data.get('continent_name')
-            self._country = {
-                'code': self._raw_data.get('country_code'),
-                'name': self._raw_data.get('country_name'),
-            }
-            self._geo_data = {
-                'latitude': self._raw_data.get('latitude'),
-                'longitude': self._raw_data.get('longitude'),
-            }
-        else:
-            self._continent = None
-            self._country = {
-                'code': None,
-                'name': None,
-            }
-            self._geo_data = {
-                'latitude': None,
-                'longitude': None,
-            }
+        self._continent = self._raw_data.get('continent_name')
+        self._country = {
+            'code': self._raw_data.get('country_code'),
+            'name': self._raw_data.get('country_name'),
+        }
+        self._geo_data = {
+            'latitude': self._raw_data.get('latitude'),
+            'longitude': self._raw_data.get('longitude'),
+        }

--- a/django_ip_geolocation/backends/ipdataco.py
+++ b/django_ip_geolocation/backends/ipdataco.py
@@ -23,13 +23,23 @@ class IPDataCo(GeolocationBackend):
 
     def _parse(self):
         """Parse raw data."""
-        self._continent = self._raw_data.get('continent_name')
-        self._country = {
-            'code': self._raw_data.get('country_code'),
-            'name': self._raw_data.get('country_name'),
-        }
-
-        self._geo_data = {
-            'latitude': self._raw_data.get('latitude'),
-            'longitude': self._raw_data.get('longitude'),
-        }
+        if self._raw_data:
+            self._continent = self._raw_data.get('continent_name')
+            self._country = {
+                'code': self._raw_data.get('country_code'),
+                'name': self._raw_data.get('country_name'),
+            }
+            self._geo_data = {
+                'latitude': self._raw_data.get('latitude'),
+                'longitude': self._raw_data.get('longitude'),
+            }
+        else:
+            self._continent = None
+            self._country = {
+                'code': None,
+                'name': None,
+            }
+            self._geo_data = {
+                'latitude': None,
+                'longitude': None,
+            }

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,24 @@
 [tox]
 envlist =
-    {py35}-django-20
-    {py36}-django-20
-    {py37}-django-22
-    {py38}-django-30
+    {py35}-django-22
+    {py36}-django-30
+    {py37}-django-31
+    {py38}-django-stable
+    {py39}-django-stable
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/django_ip_geolocation
 commands = coverage run --source django_ip_geolocation manage.py test -v2 
 deps =
-    django-20: Django>=2.0,<2.2
-    django-22: Django>=2.2
-    django-30: Django>=3.0
+    django-22: Django>=2.2,<2.3
+    django-30: Django>=3.0,<3.1
+    django-31: Django>=3.1,<3.2
+    django-stable: git+https://github.com/django/django.git@stable/3.1.x#egg=Django
     -r{toxinidir}/tests/requirements.txt
 basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    {py27}-django-111
     {py35}-django-20
     {py36}-django-20
     {py37}-django-22
@@ -11,13 +10,11 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/django_ip_geolocation
 commands = coverage run --source django_ip_geolocation manage.py test -v2 
 deps =
-    django-111: Django>=1.11,<1.12
-    django-20: Django>=2.0,<2.1
+    django-20: Django>=2.0,<2.2
     django-22: Django>=2.2
     django-30: Django>=3.0
     -r{toxinidir}/tests/requirements.txt
 basepython =
-    py27: python2.7
     py35: python3.5
     py36: python3.6
     py37: python3.7


### PR DESCRIPTION
This happens on some occasions when geolocate IP couldn't find the IP's location

Error log:
```
backend_1      |  [2021-03-24 11:20:45,391] root         ERROR    Couldn't geolocate ip (middleware 1 140405557767496)
backend_1      | Traceback (most recent call last):
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/middleware.py", line 26, in process_request
backend_1      |     self._get_geolocation(request)
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/middleware.py", line 61, in _get_geolocation
backend_1      |     self._geolocation_data = get_geolocation(request)
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/utils.py", line 52, in get_geolocation
backend_1      |     return backend_instance.data()
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/backends/base.py", line 33, in data
backend_1      |     self._parse()
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/backends/ipdataco.py", line 26, in _parse
backend_1      |     self._continent = self._raw_data.get('continent_name')
backend_1      | AttributeError: 'NoneType' object has no attribute 'get'
backend_1      | [2021-03-24 11:20:45,533] root         ERROR    Couldn't geolocate ip (middleware 1 140405557767496)
backend_1      | Traceback (most recent call last):
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/middleware.py", line 42, in process_response
backend_1      |     self._get_geolocation(request)
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/middleware.py", line 61, in _get_geolocation
backend_1      |     self._geolocation_data = get_geolocation(request)
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/utils.py", line 52, in get_geolocation
backend_1      |     return backend_instance.data()
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/backends/base.py", line 33, in data
backend_1      |     self._parse()
backend_1      |   File "/usr/local/lib/python3.8/site-packages/django_ip_geolocation/backends/ipdataco.py", line 26, in _parse
backend_1      |     self._continent = self._raw_data.get('continent_name')
backend_1      | AttributeError: 'NoneType' object has no attribute 'get'
```